### PR TITLE
feat: add restore command from Google Drive backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Laravel MySQL Drive Backup (OAuth2)
 
-Laravel 12 package to back up a MySQL database and upload the dump to Google Drive using OAuth2 (user consent). Provides two Artisan commands: one for authorization and one for backup. Suitable for manual runs and for scheduling via Laravel Scheduler.
+Laravel 12 package to back up a MySQL database and upload the dump to Google Drive using OAuth2 (user consent). Provides Artisan commands for authorization, creating backups and restoring them from Drive. Suitable for manual runs and for scheduling via Laravel Scheduler.
 
 - Package name: `artryazanov/laravel-mysql-drive-backup`
 - License: Unlicense
@@ -29,8 +29,10 @@ Configuration file: `config/drivebackup.php`
 - client_secret: Google OAuth2 Client Secret (env GOOGLE_DRIVE_CLIENT_SECRET)
 - redirect_uri: Redirect URI registered in Google Cloud Console (env GOOGLE_DRIVE_REDIRECT_URI, default http://localhost:8000/google/drive/callback)
 - token_file: Path to the token JSON file (env GOOGLE_DRIVE_TOKEN_PATH, default storage/app/google_drive_token.json)
+- drive_backup_folder_id: Optional Drive folder ID where backups are stored (env GOOGLE_DRIVE_BACKUP_FOLDER_ID)
 - backup_file_name: File name to use on Google Drive (env DB_BACKUP_NAME, default mysql_backup_{timestamp}.sql). You can include {timestamp} placeholder which is replaced as YYYYMMDD-HHMMSS.
 - temp_file_path: Local temporary dump path (env DB_BACKUP_TEMP_PATH, default storage/app/mysql_backup_{timestamp}.sql). You can include {timestamp} placeholder which is replaced as YYYYMMDD-HHMMSS.
+- restore_temp_dir: Temporary directory for downloaded archives during restore (env DB_RESTORE_TEMP_DIR, default storage/app/drive-restore-temp)
 - compress: When true (default), gzip-compress the .sql dump before upload (env DB_BACKUP_COMPRESS, default true). If enabled and backup_file_name does not end with .gz, the uploaded name will have .gz appended.
 - exclude_tables: Array of table names to exclude from backup. Set via env DB_BACKUP_EXCLUDE_TABLES as a comma-separated list (e.g., "jobs,failed_jobs,sessions"). For each listed table, mysqldump will receive --ignore-table="{database}.{table}".
 
@@ -68,7 +70,20 @@ Run the backup command:
 php artisan backup:mysql-to-drive
 ```
 
-What happens:
+Restore a backup from Google Drive:
+
+```bash
+php artisan backup:restore-mysql "backup-*.sql.gz"
+```
+
+You may restrict tables during restore:
+
+```bash
+php artisan backup:restore-mysql "backup-*.zip" --only=users,orders
+php artisan backup:restore-mysql "nightly-*.sql" --except=log_*
+```
+
+Backup command behaviour:
 1. The package creates a MySQL dump of the default connection (must be MySQL).
 2. The dump file is uploaded to Google Drive using OAuth2.
 3. On success, the local dump file is removed.

--- a/config/drivebackup.php
+++ b/config/drivebackup.php
@@ -45,6 +45,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Google Drive backup folder ID
+    |--------------------------------------------------------------------------
+    |
+    | Optional ID of the folder on Google Drive where backups are stored. When
+    | set, API requests will be limited to this folder for faster listing.
+    |
+    */
+    'drive_backup_folder_id' => env('GOOGLE_DRIVE_BACKUP_FOLDER_ID', null),
+
+    /*
+    |--------------------------------------------------------------------------
     | Backup file name on Google Drive
     |--------------------------------------------------------------------------
     |
@@ -64,6 +75,18 @@ return [
     |
     */
     'temp_file_path' => env('DB_BACKUP_TEMP_PATH', storage_path('app/mysql_backup_{timestamp}.sql')),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Temporary directory for restore operations
+    |--------------------------------------------------------------------------
+    |
+    | Directory used to download and extract backup archives during restore.
+    | Ensure the application has write permissions. The directory is not
+    | cleaned automatically; manage lifecycle as needed.
+    |
+    */
+    'restore_temp_dir' => env('DB_RESTORE_TEMP_DIR', storage_path('app/drive-restore-temp')),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Commands/RestoreMysqlFromDriveCommand.php
+++ b/src/Commands/RestoreMysqlFromDriveCommand.php
@@ -1,0 +1,421 @@
+<?php
+
+namespace Artryazanov\LaravelMysqlDriveBackup\Commands;
+
+use Artryazanov\LaravelMysqlDriveBackup\Services\GoogleDriveService;
+use Exception;
+use Illuminate\Console\Command;
+use ZipArchive;
+
+/**
+ * Restore MySQL database from a backup stored on Google Drive.
+ *
+ * Supports .sql, .gz and .zip files, optional table filtering via --only and
+ * --except options with simple wildcard support (*).
+ */
+class RestoreMysqlFromDriveCommand extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $signature = 'backup:restore-mysql
+        {mask : File name or mask (e.g. backup-*.sql|*.gz|*.zip)}
+        {--only= : Comma-separated list of tables to restore (supports * wildcard)}
+        {--except= : Comma-separated list of tables to exclude (supports * wildcard)}';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $description = 'Restore MySQL database from Google Drive backup with optional table filtering';
+
+    public function __construct(protected GoogleDriveService $drive)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $mask = (string) $this->argument('mask');
+        $only = $this->parseListOption($this->option('only'));
+        $except = $this->parseListOption($this->option('except'));
+
+        $restoreDir = rtrim((string) config('drivebackup.restore_temp_dir'), DIRECTORY_SEPARATOR);
+        if (! is_dir($restoreDir)) {
+            mkdir($restoreDir, 0775, true);
+        }
+
+        // 1) Find latest file by mask on Drive
+        $this->info("Searching Google Drive for mask: {$mask}");
+        $file = $this->findLatestDriveFileByMask($mask);
+        if (! $file) {
+            $this->error("File matching '{$mask}' not found on Google Drive.");
+            return 1;
+        }
+        $this->line("Found: {$file['name']} (modified: {$file['modifiedTime']})");
+
+        // 2) Download to temp directory
+        $localPath = $restoreDir . DIRECTORY_SEPARATOR . $file['name'];
+        $this->info('Downloading file from Google Drive...');
+        $this->drive->downloadFileTo($file['id'], $localPath);
+        $this->line('Saved to: ' . $localPath);
+
+        // 3) Prepare SQL files
+        try {
+            $sqlFiles = $this->prepareSqlFiles($localPath, $restoreDir);
+        } catch (Exception $e) {
+            $this->error('Extraction error: ' . $e->getMessage());
+            return 1;
+        }
+
+        // 4) Filter tables if required
+        try {
+            $sqlFiles = $this->filterSqlByTables($sqlFiles, $only, $except, $restoreDir);
+        } catch (Exception $e) {
+            $this->error('Table filtering error: ' . $e->getMessage());
+            return 1;
+        }
+
+        if (empty($sqlFiles)) {
+            $this->warn('No SQL files left after filtering.');
+            return 0;
+        }
+
+        // 5) Import into MySQL
+        try {
+            $this->importSqlFiles($sqlFiles);
+        } catch (Exception $e) {
+            $this->error('MySQL restore error: ' . $e->getMessage());
+            return 1;
+        }
+
+        $this->info('Restore completed successfully.');
+
+        $this->cleanupTemp($restoreDir, $file['name']);
+
+        return 0;
+    }
+
+    /**
+     * Parse comma-separated option values into array.
+     *
+     * @return array<int, string>
+     */
+    protected function parseListOption(?string $opt): array
+    {
+        if (! $opt) {
+            return [];
+        }
+        return array_values(array_filter(array_map('trim', explode(',', $opt)), fn ($s) => $s !== ''));
+    }
+
+    /**
+     * Find latest Google Drive file matching mask.
+     */
+    protected function findLatestDriveFileByMask(string $mask): ?array
+    {
+        $folderId = config('drivebackup.drive_backup_folder_id');
+        $files = $this->drive->listBackupFiles($folderId);
+
+        $regex = $this->maskToRegex($mask);
+        foreach ($files as $f) {
+            if (preg_match($regex, $f['name'])) {
+                return $f; // already sorted by modifiedTime desc
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Prepare SQL files to import from downloaded archive.
+     *
+     * @return array<int, string>
+     */
+    protected function prepareSqlFiles(string $localPath, string $restoreDir): array
+    {
+        $ext = strtolower(pathinfo($localPath, PATHINFO_EXTENSION));
+        $sqlFiles = [];
+
+        if ($ext === 'sql') {
+            $sqlFiles[] = $localPath;
+        } elseif ($ext === 'gz') {
+            $target = $restoreDir . DIRECTORY_SEPARATOR . basename($localPath, '.gz');
+            $this->gunzipTo($localPath, $target);
+            $sqlFiles[] = $target;
+        } elseif ($ext === 'zip') {
+            $sqlFiles = $this->unzipSqlFiles($localPath, $restoreDir);
+        } else {
+            throw new Exception("Unsupported file type: .{$ext}");
+        }
+
+        return $sqlFiles;
+    }
+
+    /**
+     * Decompress .gz archive into destination .sql file.
+     */
+    protected function gunzipTo(string $gzPath, string $destSql): void
+    {
+        $gz = gzopen($gzPath, 'rb');
+        if (! $gz) {
+            throw new Exception("Unable to open archive: {$gzPath}");
+        }
+        $out = fopen($destSql, 'wb');
+        if (! $out) {
+            gzclose($gz);
+            throw new Exception("Unable to create file: {$destSql}");
+        }
+        while (! gzeof($gz)) {
+            fwrite($out, gzread($gz, 1024 * 1024));
+        }
+        gzclose($gz);
+        fclose($out);
+    }
+
+    /**
+     * Extract all .sql files from a ZIP archive.
+     *
+     * @return array<int, string>
+     */
+    protected function unzipSqlFiles(string $zipPath, string $restoreDir): array
+    {
+        $zip = new ZipArchive();
+        if ($zip->open($zipPath) !== true) {
+            throw new Exception("Unable to open ZIP: {$zipPath}");
+        }
+
+        $sqlFiles = [];
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $entry = $zip->getNameIndex($i);
+            if (strtolower(pathinfo($entry, PATHINFO_EXTENSION)) === 'sql') {
+                $target = $restoreDir . DIRECTORY_SEPARATOR . basename($entry);
+                copy("zip://{$zipPath}#{$entry}", $target);
+                $sqlFiles[] = $target;
+            }
+        }
+        $zip->close();
+
+        if (empty($sqlFiles)) {
+            throw new Exception('No .sql files found inside ZIP.');
+        }
+
+        return $sqlFiles;
+    }
+
+    /**
+     * Filter SQL files by tables using --only/--except options.
+     *
+     * @return array<int, string>
+     */
+    protected function filterSqlByTables(array $sqlFiles, array $only, array $except, string $restoreDir): array
+    {
+        if (empty($only) && empty($except)) {
+            return $sqlFiles;
+        }
+
+        if (count($sqlFiles) > 1) {
+            return $this->filterMultiSqlFiles($sqlFiles, $only, $except);
+        }
+
+        $src = $sqlFiles[0];
+        $dst = $restoreDir . DIRECTORY_SEPARATOR . 'filtered-' . basename($src);
+
+        $this->filterSingleSqlFile($src, $dst, $only, $except);
+
+        if (filesize($dst) === 0) {
+            @unlink($dst);
+            return [];
+        }
+
+        return [$dst];
+    }
+
+    /**
+     * Filter multiple SQL files where each file corresponds to a table.
+     *
+     * @return array<int, string>
+     */
+    protected function filterMultiSqlFiles(array $files, array $only, array $except): array
+    {
+        $map = [];
+        foreach ($files as $f) {
+            $tbl = strtolower(pathinfo($f, PATHINFO_FILENAME));
+            $map[$tbl] = $f;
+        }
+
+        $select = array_keys($map);
+
+        if (! empty($only)) {
+            $select = $this->namesByMasks($select, $only);
+        }
+        if (! empty($except)) {
+            $exclude = $this->namesByMasks($select, $except);
+            $select = array_values(array_diff($select, $exclude));
+        }
+
+        $out = [];
+        foreach ($select as $tbl) {
+            $out[] = $map[$tbl];
+        }
+        return $out;
+    }
+
+    /**
+     * Filter single big SQL file (mysqldump format) by table blocks.
+     */
+    protected function filterSingleSqlFile(string $src, string $dst, array $only, array $except): void
+    {
+        $in = fopen($src, 'rb');
+        $out = fopen($dst, 'wb');
+        if (! $in || ! $out) {
+            if ($in) {
+                fclose($in);
+            }
+            if ($out) {
+                fclose($out);
+            }
+            throw new Exception('Unable to open files for filtering.');
+        }
+
+        $current = null;
+        $write = true;
+        $buffer = [];
+
+        $flush = function () use (&$buffer, $out): void {
+            if (! empty($buffer)) {
+                fwrite($out, implode('', $buffer));
+                $buffer = [];
+            }
+        };
+
+        $isAllowed = function (string $table) use ($only, $except): bool {
+            $table = strtolower($table);
+            if (! empty($only) && ! $this->matchesAnyMask($table, $only)) {
+                return false;
+            }
+            if (! empty($except) && $this->matchesAnyMask($table, $except)) {
+                return false;
+            }
+            return true;
+        };
+
+        while (($line = fgets($in)) !== false) {
+            if (preg_match('/^-- Table structure for table `([^`]+)`/i', $line, $m)
+                || preg_match('/^DROP TABLE IF EXISTS `([^`]+)`/i', $line, $m)
+                || preg_match('/^CREATE TABLE `([^`]+)`/i', $line, $m)
+                || preg_match('/^LOCK TABLES `([^`]+)`/i', $line, $m)
+                || preg_match('/^INSERT INTO `([^`]+)`/i', $line, $m)) {
+
+                $table = $m[1];
+
+                if ($current !== null && $current !== $table) {
+                    if ($write) {
+                        $flush();
+                    }
+                    $buffer = [];
+                }
+
+                $current = $table;
+                $write = $isAllowed($table);
+            }
+
+            if ($current === null) {
+                fwrite($out, $line);
+            } else {
+                if ($write) {
+                    $buffer[] = $line;
+                }
+
+                if (preg_match('/^UNLOCK TABLES;$/i', trim($line))) {
+                    if ($write) {
+                        $flush();
+                    }
+                    $buffer = [];
+                    $current = null;
+                    $write = true;
+                }
+            }
+        }
+
+        if ($write) {
+            $flush();
+        }
+
+        fclose($in);
+        fclose($out);
+    }
+
+    /**
+     * Import SQL files using mysql CLI.
+     *
+     * @throws Exception
+     */
+    protected function importSqlFiles(array $sqlFiles): void
+    {
+        $conn = config('database.default');
+        $db = config("database.connections.{$conn}");
+        if (! $db || ($db['driver'] ?? null) !== 'mysql') {
+            throw new Exception('Only MySQL driver is supported.');
+        }
+
+        $hostArg = $db['host'] ? '--host=' . escapeshellarg($db['host']) : '';
+        $portArg = $db['port'] ? '--port=' . escapeshellarg((string) $db['port']) : '';
+        $userArg = $db['username'] ? '--user=' . escapeshellarg($db['username']) : '';
+        $passArg = array_key_exists('password', $db)
+            ? '--password=' . escapeshellarg((string) $db['password'])
+            : '--password=';
+
+        foreach ($sqlFiles as $path) {
+            $this->info('Importing: ' . basename($path));
+            $cmd = "mysql {$hostArg} {$portArg} {$userArg} {$passArg} " . escapeshellarg((string) $db['database']) .
+                ' < ' . escapeshellarg($path) . ' 2>&1';
+            exec($cmd, $out, $code);
+            if ($code !== 0) {
+                $msg = implode("\n", $out);
+                throw new Exception("mysql exited with code {$code}: {$msg}");
+            }
+        }
+    }
+
+    /**
+     * Remove temporary artifacts created during restore.
+     */
+    protected function cleanupTemp(string $restoreDir, string $downloadedFileName): void
+    {
+        // Intentionally left blank; implement custom cleanup if needed.
+        // Users may want to keep files for inspection.
+    }
+
+    /**
+     * Convert simple wildcard mask to regex.
+     */
+    protected function maskToRegex(string $mask): string
+    {
+        $escaped = preg_quote($mask, '#');
+        $escaped = str_replace('\\*', '.*', $escaped);
+        return '#^' . $escaped . '$#i';
+    }
+
+    protected function matchesAnyMask(string $name, array $masks): bool
+    {
+        $name = strtolower($name);
+        foreach ($masks as $m) {
+            if (preg_match($this->maskToRegex($m), $name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected function namesByMasks(array $candidates, array $masks): array
+    {
+        $out = [];
+        foreach ($candidates as $n) {
+            if ($this->matchesAnyMask($n, $masks)) {
+                $out[] = $n;
+            }
+        }
+        return $out;
+    }
+}
+

--- a/src/DriveBackupServiceProvider.php
+++ b/src/DriveBackupServiceProvider.php
@@ -4,6 +4,7 @@ namespace Artryazanov\LaravelMysqlDriveBackup;
 
 use Artryazanov\LaravelMysqlDriveBackup\Commands\AuthorizeDriveCommand;
 use Artryazanov\LaravelMysqlDriveBackup\Commands\BackupMysqlToDriveCommand;
+use Artryazanov\LaravelMysqlDriveBackup\Commands\RestoreMysqlFromDriveCommand;
 use Artryazanov\LaravelMysqlDriveBackup\Services\DumpService;
 use Artryazanov\LaravelMysqlDriveBackup\Services\GoogleDriveService;
 use Illuminate\Support\ServiceProvider;
@@ -25,7 +26,8 @@ class DriveBackupServiceProvider extends ServiceProvider
             return new GoogleDriveService(
                 (string) ($config['client_id'] ?? ''),
                 (string) ($config['client_secret'] ?? ''),
-                (string) ($config['token_file'] ?? storage_path('app/google_drive_token.json'))
+                (string) ($config['token_file'] ?? storage_path('app/google_drive_token.json')),
+                $config['redirect_uri'] ?? null
             );
         });
 
@@ -49,6 +51,7 @@ class DriveBackupServiceProvider extends ServiceProvider
             $this->commands([
                 BackupMysqlToDriveCommand::class,
                 AuthorizeDriveCommand::class,
+                RestoreMysqlFromDriveCommand::class,
             ]);
         }
 

--- a/src/Services/GoogleDriveService.php
+++ b/src/Services/GoogleDriveService.php
@@ -20,7 +20,7 @@ class GoogleDriveService
     {
         $this->tokenFile = $tokenFile;
 
-        $this->client = new Client();
+        $this->client = new Client;
         $this->client->setClientId($clientId);
         $this->client->setClientSecret($clientSecret);
         if ($redirectUri) {
@@ -48,7 +48,7 @@ class GoogleDriveService
     {
         $token = $this->client->fetchAccessTokenWithAuthCode($authCode);
         if (isset($token['error'])) {
-            throw new Exception('Google token error: ' . $token['error']);
+            throw new Exception('Google token error: '.$token['error']);
         }
         $this->client->setAccessToken($token);
         $this->saveTokenToFile($this->client->getAccessToken());
@@ -75,7 +75,7 @@ class GoogleDriveService
             }
             $new = $this->client->fetchAccessTokenWithRefreshToken($refresh);
             if (isset($new['error'])) {
-                throw new Exception('Failed to refresh access token: ' . $new['error']);
+                throw new Exception('Failed to refresh access token: '.$new['error']);
             }
             $this->saveTokenToFile($this->client->getAccessToken());
         }
@@ -85,6 +85,7 @@ class GoogleDriveService
      * List files (id, name, modifiedTime, mimeType) optionally within a folder.
      *
      * @return array<array{id:string, name:string, modifiedTime:string, mimeType:string}>
+     *
      * @throws Exception
      */
     public function listBackupFiles(?string $folderId = null): array
@@ -92,7 +93,7 @@ class GoogleDriveService
         $this->ensureAccessToken();
         $service = new Drive($this->client);
 
-        $query = "trashed = false";
+        $query = 'trashed = false';
         if ($folderId) {
             $query .= " and '{$folderId}' in parents";
         }
@@ -145,7 +146,7 @@ class GoogleDriveService
 
         $fh = fopen($destPath, 'w');
         if (! $fh) {
-            throw new Exception('Unable to open file for writing: ' . $destPath);
+            throw new Exception('Unable to open file for writing: '.$destPath);
         }
         while (! $body->eof()) {
             fwrite($fh, $body->read(1024 * 1024));
@@ -185,4 +186,3 @@ class GoogleDriveService
         @chmod($this->tokenFile, 0600);
     }
 }
-

--- a/src/Services/GoogleDriveService.php
+++ b/src/Services/GoogleDriveService.php
@@ -7,23 +7,25 @@ use Google\Client;
 use Google\Service\Drive;
 use Google\Service\Drive\DriveFile;
 
+/**
+ * Service wrapper around Google Drive API client used for backup and restore.
+ */
 class GoogleDriveService
 {
     protected Client $client;
 
     protected string $tokenFile;
 
-    /**
-     * Configure Google API Client for OAuth2 with given credentials.
-     */
-    public function __construct(string $clientId, string $clientSecret, string $tokenFile)
+    public function __construct(string $clientId, string $clientSecret, string $tokenFile, ?string $redirectUri = null)
     {
         $this->tokenFile = $tokenFile;
 
-        $this->client = new Client;
+        $this->client = new Client();
         $this->client->setClientId($clientId);
         $this->client->setClientSecret($clientSecret);
-        $this->client->setRedirectUri((string) config('drivebackup.redirect_uri'));
+        if ($redirectUri) {
+            $this->client->setRedirectUri($redirectUri);
+        }
         $this->client->setAccessType('offline');
         $this->client->setPrompt('consent');
         $this->client->setScopes([Drive::DRIVE_FILE]);
@@ -46,64 +48,141 @@ class GoogleDriveService
     {
         $token = $this->client->fetchAccessTokenWithAuthCode($authCode);
         if (isset($token['error'])) {
-            throw new Exception('Error fetching Google OAuth token: '.$token['error']);
+            throw new Exception('Google token error: ' . $token['error']);
         }
         $this->client->setAccessToken($token);
         $this->saveTokenToFile($this->client->getAccessToken());
     }
 
     /**
-     * Upload file to Google Drive under the provided name; refresh token when needed.
+     * Ensure we have a valid access token, refreshing if needed.
+     *
+     * @throws Exception
+     */
+    protected function ensureAccessToken(): void
+    {
+        if (! file_exists($this->tokenFile)) {
+            throw new Exception('Token file not found. Run authorization first.');
+        }
+
+        $token = json_decode((string) file_get_contents($this->tokenFile), true) ?: [];
+        $this->client->setAccessToken($token);
+
+        if ($this->client->isAccessTokenExpired()) {
+            $refresh = $this->client->getRefreshToken();
+            if (! $refresh) {
+                throw new Exception('No refresh token. Re-run authorization.');
+            }
+            $new = $this->client->fetchAccessTokenWithRefreshToken($refresh);
+            if (isset($new['error'])) {
+                throw new Exception('Failed to refresh access token: ' . $new['error']);
+            }
+            $this->saveTokenToFile($this->client->getAccessToken());
+        }
+    }
+
+    /**
+     * List files (id, name, modifiedTime, mimeType) optionally within a folder.
+     *
+     * @return array<array{id:string, name:string, modifiedTime:string, mimeType:string}>
+     * @throws Exception
+     */
+    public function listBackupFiles(?string $folderId = null): array
+    {
+        $this->ensureAccessToken();
+        $service = new Drive($this->client);
+
+        $query = "trashed = false";
+        if ($folderId) {
+            $query .= " and '{$folderId}' in parents";
+        }
+
+        $files = [];
+        $pageToken = null;
+        do {
+            $params = [
+                'q' => $query,
+                'fields' => 'nextPageToken, files(id, name, mimeType, modifiedTime)',
+                'orderBy' => 'modifiedTime desc',
+                'pageSize' => 1000,
+            ];
+            if ($pageToken) {
+                $params['pageToken'] = $pageToken;
+            }
+
+            $resp = $service->files->listFiles($params);
+            foreach ($resp->getFiles() as $f) {
+                $files[] = [
+                    'id' => $f->getId(),
+                    'name' => $f->getName(),
+                    'mimeType' => $f->getMimeType(),
+                    'modifiedTime' => $f->getModifiedTime(),
+                ];
+            }
+            $pageToken = $resp->getNextPageToken();
+        } while ($pageToken);
+
+        return $files;
+    }
+
+    /**
+     * Download file contents from Drive to local path.
+     *
+     * @throws Exception
+     */
+    public function downloadFileTo(string $fileId, string $destPath): void
+    {
+        $this->ensureAccessToken();
+        $service = new Drive($this->client);
+
+        $response = $service->files->get($fileId, ['alt' => 'media']);
+        $body = $response->getBody();
+
+        $dir = dirname($destPath);
+        if (! is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+
+        $fh = fopen($destPath, 'w');
+        if (! $fh) {
+            throw new Exception('Unable to open file for writing: ' . $destPath);
+        }
+        while (! $body->eof()) {
+            fwrite($fh, $body->read(1024 * 1024));
+        }
+        fclose($fh);
+    }
+
+    /**
+     * Upload file to Google Drive under the provided name.
      *
      * @throws Exception
      */
     public function uploadFile(string $filePath, string $driveFileName): void
     {
-        if (! is_file($this->tokenFile)) {
-            throw new Exception('Token file not found, authorization required.');
-        }
-        $saved = json_decode((string) file_get_contents($this->tokenFile), true) ?: [];
-        $this->client->setAccessToken($saved);
-
-        if ($this->client->isAccessTokenExpired()) {
-            if ($this->client->getRefreshToken()) {
-                $newToken = $this->client->fetchAccessTokenWithRefreshToken($this->client->getRefreshToken());
-                if (isset($newToken['error'])) {
-                    throw new Exception('Failed to refresh access token: '.$newToken['error']);
-                }
-                $this->saveTokenToFile($this->client->getAccessToken());
-            } else {
-                throw new Exception('No refresh token available. Re-authorize.');
-            }
-        }
-
+        $this->ensureAccessToken();
         $drive = new Drive($this->client);
-        $fileMeta = new DriveFile(['name' => $driveFileName]);
-        $content = file_get_contents($filePath);
-        if ($content === false) {
-            throw new Exception('Failed to read local file for upload.');
-        }
 
-        $drive->files->create($fileMeta, [
-            'data' => $content,
+        $meta = new DriveFile(['name' => $driveFileName]);
+        $drive->files->create($meta, [
+            'data' => file_get_contents($filePath),
             'mimeType' => 'application/octet-stream',
             'uploadType' => 'multipart',
         ]);
     }
 
     /**
-     * Save token JSON to file.
-     *
-     * @throws Exception
+     * Persist OAuth token to file.
      */
-    private function saveTokenToFile(array $tokenData): void
+    private function saveTokenToFile(array $token): void
     {
         $dir = dirname($this->tokenFile);
         if (! is_dir($dir)) {
-            @mkdir($dir, 0700, true);
+            mkdir($dir, 0700, true);
         }
-        if (file_put_contents($this->tokenFile, json_encode($tokenData)) === false) {
-            throw new Exception('Unable to persist OAuth token to: '.$this->tokenFile);
-        }
+
+        file_put_contents($this->tokenFile, json_encode($token, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        @chmod($this->tokenFile, 0600);
     }
 }
+

--- a/tests/Unit/ProviderTest.php
+++ b/tests/Unit/ProviderTest.php
@@ -14,6 +14,8 @@ class ProviderTest extends TestCase
         $this->assertIsString(config('drivebackup.client_secret'));
         $this->assertIsString(config('drivebackup.token_file'));
         $this->assertIsString(config('drivebackup.temp_file_path'));
+        $this->assertIsString(config('drivebackup.restore_temp_dir'));
+        $this->assertNull(config('drivebackup.drive_backup_folder_id'));
         $this->assertTrue(filter_var(config('drivebackup.compress'), FILTER_VALIDATE_BOOL));
         $this->assertIsArray(config('drivebackup.exclude_tables'));
     }
@@ -23,5 +25,6 @@ class ProviderTest extends TestCase
         $commands = Artisan::all();
         $this->assertArrayHasKey('backup:mysql-to-drive', $commands);
         $this->assertArrayHasKey('backup:authorize-drive', $commands);
+        $this->assertArrayHasKey('backup:restore-mysql', $commands);
     }
 }


### PR DESCRIPTION
## Summary
- support restoring MySQL backups from Google Drive with optional table filtering and archive extraction
- add Drive list/download helpers and expose new config for restore temp dir and optional Drive folder
- document new usage and verify command registration

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6898f79933348332ac6cf56c3255d77d