### PR TITLE
feat: add cleanup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ php artisan backup:restore-mysql "backup-*.zip" --only=users,orders
 php artisan backup:restore-mysql "nightly-*.sql" --except=log_*
 ```
 
+Remove outdated backups from Google Drive according to the retention policy:
+
+```bash
+php artisan backup:cleanup-drive
+```
+
 Backup command behaviour:
 1. The package creates a MySQL dump of the default connection (must be MySQL).
 2. The dump file is uploaded to Google Drive using OAuth2.
@@ -94,6 +100,7 @@ Add this to your `app/Console/Kernel.php` schedule method:
 
 ```php
 $schedule->command('backup:mysql-to-drive')->dailyAt('03:00');
+$schedule->command('backup:cleanup-drive')->dailyAt('04:00');
 ```
 
 ## Troubleshooting

--- a/src/Commands/CleanupDriveBackupsCommand.php
+++ b/src/Commands/CleanupDriveBackupsCommand.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Artryazanov\LaravelMysqlDriveBackup\Commands;
+
+use Artryazanov\LaravelMysqlDriveBackup\Services\GoogleDriveService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+/**
+ * Remove outdated backup files from Google Drive based on retention policy.
+ */
+class CleanupDriveBackupsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     */
+    protected $signature = 'backup:cleanup-drive';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Remove outdated backups from Google Drive according to retention rules';
+
+    public function __construct(protected GoogleDriveService $drive)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $pattern = (string) config('drivebackup.backup_file_name');
+        if ($pattern === '') {
+            $this->error('Config backup_file_name is empty.');
+
+            return 1;
+        }
+
+        $regex = $this->buildRegex($pattern);
+        $folderId = config('drivebackup.drive_backup_folder_id');
+
+        try {
+            $files = $this->drive->listBackupFiles($folderId);
+        } catch (\Exception $e) {
+            $this->error('Failed to list files: '.$e->getMessage());
+
+            return 1;
+        }
+
+        $backups = [];
+        foreach ($files as $file) {
+            if (preg_match($regex, $file['name'])) {
+                $backups[] = [
+                    'id' => $file['id'],
+                    'name' => $file['name'],
+                    'time' => Carbon::parse($file['modifiedTime']),
+                ];
+            }
+        }
+
+        if (empty($backups)) {
+            $this->info('No backups found.');
+
+            return 0;
+        }
+
+        usort($backups, fn ($a, $b) => $a['time']->timestamp <=> $b['time']->timestamp);
+
+        $toKeep = [];
+        $toDelete = [];
+
+        // Daily: keep last per day
+        $byDay = [];
+        foreach ($backups as $file) {
+            $key = $file['time']->toDateString();
+            $byDay[$key][] = $file;
+        }
+        foreach ($byDay as $filesByDay) {
+            $last = array_pop($filesByDay);
+            $toKeep[] = $last;
+            foreach ($filesByDay as $old) {
+                $toDelete[] = $old;
+            }
+        }
+
+        $now = Carbon::now();
+
+        // Weekly: keep last per week except current and previous week
+        $currentWeek = $now->isoWeekYear.'-'.$now->isoWeek;
+        $previousWeekCarbon = $now->copy()->subWeek();
+        $previousWeek = $previousWeekCarbon->isoWeekYear.'-'.$previousWeekCarbon->isoWeek;
+
+        $byWeek = [];
+        foreach ($toKeep as $file) {
+            $wk = $file['time']->isoWeekYear.'-'.$file['time']->isoWeek;
+            $byWeek[$wk][] = $file;
+        }
+        $toKeep = [];
+        foreach ($byWeek as $week => $filesByWeek) {
+            if ($week === $currentWeek || $week === $previousWeek) {
+                foreach ($filesByWeek as $f) {
+                    $toKeep[] = $f;
+                }
+            } else {
+                $last = array_pop($filesByWeek);
+                $toKeep[] = $last;
+                foreach ($filesByWeek as $old) {
+                    $toDelete[] = $old;
+                }
+            }
+        }
+
+        // Monthly: keep last per month except current and previous month
+        $currentMonth = $now->format('Y-m');
+        $previousMonth = $now->copy()->subMonth()->format('Y-m');
+
+        $byMonth = [];
+        foreach ($toKeep as $file) {
+            $m = $file['time']->format('Y-m');
+            $byMonth[$m][] = $file;
+        }
+        $toKeep = [];
+        foreach ($byMonth as $month => $filesByMonth) {
+            if ($month === $currentMonth || $month === $previousMonth) {
+                foreach ($filesByMonth as $f) {
+                    $toKeep[] = $f;
+                }
+            } else {
+                $last = array_pop($filesByMonth);
+                $toKeep[] = $last;
+                foreach ($filesByMonth as $old) {
+                    $toDelete[] = $old;
+                }
+            }
+        }
+
+        // Yearly: keep last per year except current and previous year
+        $currentYear = $now->format('Y');
+        $previousYear = $now->copy()->subYear()->format('Y');
+
+        $byYear = [];
+        foreach ($toKeep as $file) {
+            $y = $file['time']->format('Y');
+            $byYear[$y][] = $file;
+        }
+        $toKeep = [];
+        foreach ($byYear as $year => $filesByYear) {
+            $year = (string) $year;
+            if ($year === $currentYear || $year === $previousYear) {
+                foreach ($filesByYear as $f) {
+                    $toKeep[] = $f;
+                }
+            } else {
+                $last = array_pop($filesByYear);
+                $toKeep[] = $last;
+                foreach ($filesByYear as $old) {
+                    $toDelete[] = $old;
+                }
+            }
+        }
+
+        if (empty($toDelete)) {
+            $this->info('No outdated backups to delete.');
+
+            return 0;
+        }
+
+        foreach ($toDelete as $file) {
+            try {
+                $this->drive->deleteFile($file['id']);
+                $this->line('Deleted backup: '.$file['name']);
+            } catch (\Exception $e) {
+                $this->error('Failed to delete '.$file['name'].': '.$e->getMessage());
+            }
+        }
+
+        $this->info('Cleanup completed.');
+
+        return 0;
+    }
+
+    /**
+     * Build regex to match backup file name pattern from config.
+     */
+    protected function buildRegex(string $pattern): string
+    {
+        $regex = preg_quote($pattern, '#');
+        $regex = str_replace('\\{timestamp\\}', '.*', $regex);
+        if (! str_ends_with($pattern, '.gz')) {
+            $regex .= '(?:\\.gz)?';
+        }
+
+        return '#^'.$regex.'$#';
+    }
+}
+

--- a/src/DriveBackupServiceProvider.php
+++ b/src/DriveBackupServiceProvider.php
@@ -4,6 +4,7 @@ namespace Artryazanov\LaravelMysqlDriveBackup;
 
 use Artryazanov\LaravelMysqlDriveBackup\Commands\AuthorizeDriveCommand;
 use Artryazanov\LaravelMysqlDriveBackup\Commands\BackupMysqlToDriveCommand;
+use Artryazanov\LaravelMysqlDriveBackup\Commands\CleanupDriveBackupsCommand;
 use Artryazanov\LaravelMysqlDriveBackup\Commands\RestoreMysqlFromDriveCommand;
 use Artryazanov\LaravelMysqlDriveBackup\Services\DumpService;
 use Artryazanov\LaravelMysqlDriveBackup\Services\GoogleDriveService;
@@ -52,6 +53,7 @@ class DriveBackupServiceProvider extends ServiceProvider
                 BackupMysqlToDriveCommand::class,
                 AuthorizeDriveCommand::class,
                 RestoreMysqlFromDriveCommand::class,
+                CleanupDriveBackupsCommand::class,
             ]);
         }
 

--- a/src/Services/GoogleDriveService.php
+++ b/src/Services/GoogleDriveService.php
@@ -173,6 +173,18 @@ class GoogleDriveService
     }
 
     /**
+     * Delete file from Google Drive by its ID.
+     *
+     * @throws Exception
+     */
+    public function deleteFile(string $fileId): void
+    {
+        $this->ensureAccessToken();
+        $drive = new Drive($this->client);
+        $drive->files->delete($fileId);
+    }
+
+    /**
      * Persist OAuth token to file.
      */
     private function saveTokenToFile(array $token): void

--- a/tests/Unit/CleanupDriveBackupsCommandTest.php
+++ b/tests/Unit/CleanupDriveBackupsCommandTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Artryazanov\LaravelMysqlDriveBackup\Tests\Unit;
+
+use Artryazanov\LaravelMysqlDriveBackup\Services\GoogleDriveService;
+use Artryazanov\LaravelMysqlDriveBackup\Tests\TestCase;
+use Illuminate\Support\Carbon;
+
+/**
+ * @internal
+ */
+class CleanupDriveBackupsCommandTest extends TestCase
+{
+    public function test_removes_old_backups(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2024-01-20 00:00:00'));
+
+        config(['drivebackup.backup_file_name' => 'backup_{timestamp}.sql']);
+
+        $service = new class extends GoogleDriveService {
+            public array $files = [];
+            public array $deleted = [];
+            public function __construct() {}
+            public function listBackupFiles(?string $folderId = null): array
+            {
+                return $this->files;
+            }
+            public function deleteFile(string $fileId): void
+            {
+                $this->deleted[] = $fileId;
+            }
+        };
+
+        $service->files = [
+            ['id' => '1', 'name' => 'backup_20240120-100000.sql.gz', 'modifiedTime' => '2024-01-20T10:00:00+00:00'],
+            ['id' => '2', 'name' => 'backup_20240120-150000.sql.gz', 'modifiedTime' => '2024-01-20T15:00:00+00:00'],
+            ['id' => '3', 'name' => 'backup_20240119-120000.sql.gz', 'modifiedTime' => '2024-01-19T12:00:00+00:00'],
+            ['id' => '4', 'name' => 'backup_20240113-120000.sql.gz', 'modifiedTime' => '2024-01-13T12:00:00+00:00'],
+            ['id' => '5', 'name' => 'backup_20240107-120000.sql.gz', 'modifiedTime' => '2024-01-07T12:00:00+00:00'],
+            ['id' => '6', 'name' => 'backup_20240105-120000.sql.gz', 'modifiedTime' => '2024-01-05T12:00:00+00:00'],
+            ['id' => '7', 'name' => 'backup_20231215-120000.sql.gz', 'modifiedTime' => '2023-12-15T12:00:00+00:00'],
+            ['id' => '8', 'name' => 'backup_20231210-120000.sql.gz', 'modifiedTime' => '2023-12-10T12:00:00+00:00'],
+            ['id' => '9', 'name' => 'backup_20231120-120000.sql.gz', 'modifiedTime' => '2023-11-20T12:00:00+00:00'],
+            ['id' => '10', 'name' => 'backup_20231110-120000.sql.gz', 'modifiedTime' => '2023-11-10T12:00:00+00:00'],
+            ['id' => '11', 'name' => 'backup_20220801-120000.sql.gz', 'modifiedTime' => '2022-08-01T12:00:00+00:00'],
+            ['id' => '12', 'name' => 'backup_20220501-120000.sql.gz', 'modifiedTime' => '2022-05-01T12:00:00+00:00'],
+            ['id' => 'x', 'name' => 'otherfile.sql.gz', 'modifiedTime' => '2024-01-20T15:00:00+00:00'],
+        ];
+
+        $this->app->instance(GoogleDriveService::class, $service);
+
+        $this->artisan('backup:cleanup-drive')
+            ->assertExitCode(0)
+            ->expectsOutputToContain('Cleanup completed.');
+
+        $this->assertSame(['1', '6', '10', '12'], $service->deleted);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `backup:cleanup-drive` command to prune old backups on Google Drive
- register cleanup command, expose Drive file deletion helper, and document cleanup usage
- cover cleanup logic with unit tests

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6899b84b526c8332b0e4ade827a08167